### PR TITLE
fix: ensure rotoscope injected

### DIFF
--- a/dist/ng-describe.js
+++ b/dist/ng-describe.js
@@ -3044,6 +3044,10 @@ if (parseInt(ws + '08') !== 8 || parseInt(ws + '0x16') !== 22) {
       });
 
       function injectDependencies($injector) {
+        if(options.inject.indexOf('$rootScope') === -1) {
+          options.inject.push('$rootScope');
+        }
+
         log('injecting', options.inject);
 
         options.inject.forEach(function (dependencyName) {

--- a/src/ng-describe.js
+++ b/src/ng-describe.js
@@ -272,6 +272,10 @@
       });
 
       function injectDependencies($injector) {
+        if(options.inject.indexOf('$rootScope') === -1) {
+          options.inject.push('$rootScope');
+        }
+
         log('injecting', options.inject);
 
         options.inject.forEach(function (dependencyName) {

--- a/test/step-spec.js
+++ b/test/step-spec.js
@@ -1,0 +1,16 @@
+/* global ngDescribe, it */
+ngDescribe({
+  inject: ['$q'],
+  tests: function (deps) {
+    it('has a step method when rootscope not injected', function () {
+      la(check.fn(deps.step), 'has step method', deps);
+    });
+    it('step method triggers digest when rootscope not injected', function (done) {
+      deps.$q.when(42).then(function (value) {
+        la(value === 42);
+        done();
+      });
+      deps.step();
+    });
+  }
+});


### PR DESCRIPTION
RE #60.  Original PR did not properly ensure `deps.step()` would work when `$rootScope` was not manually injected.  Because `$rootScope` was not injected, tests that did not inject `$rootscope` would all timeout.

Since none of the existing specs tested without injecting `$rootScope`, the PR passed all tests.

Have added `step-spec` test to ensure `deps.step()` works properly when `$rootScope` not manually injected.