### PR TITLE
Updated README.md - fixed typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ ngDescribe({
         it('finally a test', function () {
             expect(foo).toEqual('bar');
         });
-    });
+    }
 });
 ```
 ng-describe can inject dependencies, mock modules, set configs, create controllers, scopes, and


### PR DESCRIPTION
In first ngDescribe example in the README.md there is a typo. An extra parenthesis and semi-colon have been removed. Users copying this block might be confused by the fact that their linters will show errors in the copied code.