### PR TITLE
Strange promise behavior.

### DIFF
--- a/test/promise-spec.js
+++ b/test/promise-spec.js
@@ -1,0 +1,49 @@
+angular.module('ServiceModule', [])
+    .factory('s1', function ($q) {
+      var S1 = function () {
+        this.deferred = $q.defer();
+      };
+
+      S1.prototype.resolveWith = function (value) {
+        this.deferred.resolve(value);
+      };
+
+      S1.prototype.getPromise = function () {
+        return this.deferred.promise;
+      };
+      return new S1();
+    })
+    .factory('ParentService', function (s1) {
+      var ParentService = function () {
+      };
+
+      ParentService.prototype.resolveService = function () {
+        s1.getPromise().then(function (done) {
+          done();
+        });
+      };
+
+      return ParentService;
+    });
+
+/* global ngDescribe, it, xit */
+ngDescribe({
+  name: 'promises resolve across tests',
+  modules: 'ServiceModule',
+  tests: function ($rootScope, s1, ParentService) {
+    it('it can resolve promise once', function (done) {
+      var parent = new ParentService();
+      parent.resolveService();
+      s1.resolveWith(done);
+      $rootScope.$apply();
+    });
+
+    // If both tests are run, it fails, either of them individually will pass
+    xit('it can resolve promise twice', function (done) {
+      var parent = new ParentService();
+      parent.resolveService();
+      s1.resolveWith(done);
+      $rootScope.$apply();
+    });
+  }
+});


### PR DESCRIPTION
While using ng-describe, I ran into an issue resolving promises across tests. If the promise to be resolved comes from another service within the service under test, that promise will only resolve once. Despite new instances of everything being created for each test.

I've created a set of tests that demonstrate the issue here.

Additionally, I have pulled these same tests out of ng-describe and they run as expected. This had worked fine until upgrading to angular 1.5, in case that could be a hint, but I'm not sure that's the cause.

I'm really not sure where to begin debugging this, otherwise I would look a bit more at it myself. If you had some suggestions, I'd be happy to attempt a PR with a fix.